### PR TITLE
Force Node 24 for GitHub Pages deployment job

### DIFF
--- a/.github/workflows/update-and-generate.yml
+++ b/.github/workflows/update-and-generate.yml
@@ -55,6 +55,8 @@ jobs:
   deploy-page:
     needs: update-prices
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Summary
Updated the GitHub Actions workflow to explicitly configure the deploy-page job to use Node 24 for JavaScript-based actions.

## Changes
- Added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` environment variable to the `deploy-page` job in the update-and-generate workflow

## Details
This change ensures that any JavaScript-based GitHub Actions executed during the GitHub Pages deployment step will run on Node 24, providing consistency and compatibility with the latest Node.js runtime environment.

https://claude.ai/code/session_01Y69m8og53X3DMCyLKeE9Dt